### PR TITLE
Add kn installation to root e2e test script

### DIFF
--- a/plugins/hello/test/e2e-tests.sh
+++ b/plugins/hello/test/e2e-tests.sh
@@ -19,6 +19,7 @@ source "$(dirname $0)"/../../../test-infra/scripts/e2e-tests.sh
 
 echo "TEST_INFRA_SCRIPTS: $TEST_INFRA_SCRIPTS"
 echo "Testing hello"
+cd ${REPO_ROOT_DIR}
 
 run() {
 
@@ -30,5 +31,4 @@ run() {
 }
 
 # Fire up
-cd ${REPO_ROOT_DIR}
 run $@

--- a/test/common.sh
+++ b/test/common.sh
@@ -68,3 +68,9 @@ function knative_setup() {
     start_release_knative_eventing "${eventing_version}"
   fi
 }
+
+function cluster_setup() {
+  header "Installing client"
+  go get knative.dev/client
+  go install knative.dev/client/cmd/kn
+}

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -22,7 +22,9 @@ run() {
 plugins_test() {
   # Iterate over all plugin directories and check whether they have testing
   # enabled
-  echo "=== Running Plugins E2E tests ======================================="
+  echo "==== Building Plugins ============================"
+  loop_over_plugins "presubmit-tests.sh" "--build-tests"
+  echo "==== Running Plugins E2E tests ============================"
   loop_over_plugins "e2e-tests.sh" ""
 }
 


### PR DESCRIPTION
This PR includes below changes:
- Add kn installation to root e2e test script.
- Update e2e-test.sh to build plugins before running the e2e test.