### PR TITLE
Update test-infra to stop using serving.yaml

### DIFF
--- a/scripts/test-infra/library.sh
+++ b/scripts/test-infra/library.sh
@@ -449,14 +449,18 @@ function report_go_test() {
 }
 
 # Install Knative Serving in the current cluster.
-# Parameters: $1 - Knative Serving manifest.
+# Parameters: $1 - Knative Serving crds manifest.
+#             $2 - Knative Serving core manifest.
+#             $3 - Knative net-istio manifest.
 function start_knative_serving() {
   header "Starting Knative Serving"
   subheader "Installing Knative Serving"
   echo "Installing Serving CRDs from $1"
-  kubectl apply --selector knative.dev/crd-install=true -f "$1"
-  echo "Installing the rest of serving components from $1"
   kubectl apply -f "$1"
+  echo "Installing Serving core components from $2"
+  kubectl apply -f "$2"
+  echo "Installing net-istio components from $3"
+  kubectl apply -f "$3"
   wait_until_pods_running knative-serving || return 1
 }
 
@@ -478,12 +482,14 @@ function start_knative_monitoring() {
 # Install the stable release Knative/serving in the current cluster.
 # Parameters: $1 - Knative Serving version number, e.g. 0.6.0.
 function start_release_knative_serving() {
-  start_knative_serving "https://storage.googleapis.com/knative-releases/serving/previous/v$1/serving.yaml"
+  start_knative_serving "https://storage.googleapis.com/knative-releases/serving/previous/v$1/serving-crds.yaml" \
+    "https://storage.googleapis.com/knative-releases/serving/previous/v$1/serving-core.yaml" \
+    "https://storage.googleapis.com/knative-releases/net-istio/previous/v$1/net-istio.yaml"
 }
 
 # Install the latest stable Knative Serving in the current cluster.
 function start_latest_knative_serving() {
-  start_knative_serving "${KNATIVE_SERVING_RELEASE}"
+  start_knative_serving "${KNATIVE_SERVING_RELEASE_CRDS}" "${KNATIVE_SERVING_RELEASE_CORE}" "${KNATIVE_NET_ISTIO_RELEASE}"
 }
 
 # Install Knative Eventing in the current cluster.
@@ -742,6 +748,8 @@ readonly _TEST_INFRA_SCRIPTS_DIR="$(dirname $(get_canonical_path ${BASH_SOURCE[0
 readonly REPO_NAME_FORMATTED="Knative $(capitalize ${REPO_NAME//-/ })"
 
 # Public latest nightly or release yaml files.
-readonly KNATIVE_SERVING_RELEASE="$(get_latest_knative_yaml_source "serving" "serving")"
+readonly KNATIVE_SERVING_RELEASE_CRDS="$(get_latest_knative_yaml_source "serving" "serving-crds")"
+readonly KNATIVE_SERVING_RELEASE_CORE="$(get_latest_knative_yaml_source "serving" "serving-core")"
+readonly KNATIVE_NET_ISTIO_RELEASE="$(get_latest_knative_yaml_source "net-istio" "net-istio")"
 readonly KNATIVE_EVENTING_RELEASE="$(get_latest_knative_yaml_source "eventing" "eventing")"
 readonly KNATIVE_MONITORING_RELEASE="$(get_latest_knative_yaml_source "serving" "monitoring")"


### PR DESCRIPTION
Serving is going to stop releasing serving.yaml, update test-infra to the latest to stop using it.

Refer to @chizhg 's update to Client: https://github.com/knative/client/pull/876