### PR TITLE
[kn-admin]Add support to remove registry with credentials

### DIFF
--- a/plugins/admin/README.adoc
+++ b/plugins/admin/README.adoc
@@ -69,7 +69,9 @@ Manage Service deployment from a private registry
 For example:
 
 kn admin registry add \
+  --secret-name=[SECRET_NAME]
   --server=[REGISTRY_SERVER_URL] \
+  --email=[REGISTRY_EMAIL] \
   --username=[REGISTRY_USER] \
   --password=[REGISTRY_PASSWORD]
 
@@ -77,15 +79,17 @@ Usage:
   kn admin registry [command]
 
 Available Commands:
-  add     Add a Service deployment from a registry
+  add         add registry with credentials
+  help        Help about any command
+  remove      Remove registry settings
 
 Flags:
-  -h, --help   help for private-registry
+  -h, --help   help for registry
 
 Global Flags:
       --config string   config file (default is $HOME/.config/kn/plugins/admin.yaml)
 
-Use "admin registry [command] --help" for more information about a command.
+Use "kn admin registry [command] --help" for more information about a command.
 
 ----
 
@@ -149,6 +153,15 @@ $ kn admin registry add \
   --server=[REGISTRY_SERVER_URL] \
   --username=[REGISTRY_USER] \
   --password=[REGISTRY_PASSWORD]
+-----
+=====
+
+.Remove a private registry by server and username.
+=====
+-----
+$ kn admin registry remove \
+  --username=[REGISTRY_USER] \
+  --server=[REGISTRY_SERVER_URL]
 -----
 =====
 

--- a/plugins/admin/pkg/command/autoscaling/update.go
+++ b/plugins/admin/pkg/command/autoscaling/update.go
@@ -17,6 +17,7 @@ package autoscaling
 import (
 	"errors"
 	"fmt"
+
 	"knative.dev/client-contrib/plugins/admin/pkg"
 
 	"github.com/spf13/cobra"

--- a/plugins/admin/pkg/command/autoscaling/update_test.go
+++ b/plugins/admin/pkg/command/autoscaling/update_test.go
@@ -131,4 +131,3 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 
 	})
 }
-

--- a/plugins/admin/pkg/command/registry/add.go
+++ b/plugins/admin/pkg/command/registry/add.go
@@ -35,24 +35,9 @@ type prcmdFlags struct {
 	Password   string
 }
 
-type Registry struct {
-	Auths Auths `json:"auths"`
-}
-type RegistryCred struct {
-	Username string `json:"Username"`
-	Password string `json:"Password"`
-	Email    string `json:"Email"`
-}
-
-type Auths map[string]RegistryCred
-
-//
-//type Info map[string]Person
-
 var prflags prcmdFlags
 
-// addCmd represents the add command
-
+// NewPrAddCommand represents the add command
 func NewPrAddCommand(p *pkg.AdminParams) *cobra.Command {
 	var prAddCmd = &cobra.Command{
 		Use:   "add",
@@ -81,7 +66,7 @@ kn admin registry add \
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dockerCfg := Registry{
 				Auths: Auths{
-					prflags.Server: RegistryCred{
+					prflags.Server: DockerCred{
 						Username: prflags.Username,
 						Password: prflags.Password,
 						Email:    prflags.Email,
@@ -92,7 +77,7 @@ kn admin registry add \
 			j, err := json.Marshal(dockerCfg)
 
 			secretData := map[string][]byte{
-				".dockerconfigjson": j,
+				DockerJSONName: j,
 			}
 
 			secret := &corev1.Secret{
@@ -104,6 +89,7 @@ kn admin registry add \
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: fmt.Sprintf("%s-", prflags.SecretName),
 					Namespace:    "default",
+					Labels:       AdminRegistryLabels,
 				},
 				Data: secretData,
 			}

--- a/plugins/admin/pkg/command/registry/add_test.go
+++ b/plugins/admin/pkg/command/registry/add_test.go
@@ -33,14 +33,14 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 )
 
-func TestNewPrAddCommand(t *testing.T) {
+func TestNewRegistryAddCommand(t *testing.T) {
 
 	t.Run("incompleted args for registry add", func(t *testing.T) {
 		client := k8sfake.NewSimpleClientset()
 		p := pkg.AdminParams{
 			ClientSet: client,
 		}
-		cmd := NewPrAddCommand(&p)
+		cmd := NewRegistryAddCommand(&p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--username", "")
 		assert.ErrorContains(t, err, "requires the registry username")
@@ -58,9 +58,9 @@ func TestNewPrAddCommand(t *testing.T) {
 			ClientSet: client,
 		}
 
-		cmd := NewPrAddCommand(&p)
+		cmd := NewRegistryAddCommand(&p)
 		_, err := testutil.ExecuteCommand(cmd, "--username", "user", "--password", "dummy", "--server", "docker.io")
-		assert.ErrorContains(t, err, "failed to get serviceaccount")
+		assert.ErrorContains(t, err, "failed to get ServiceAccount")
 	})
 
 	t.Run("adding registry secret success", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestNewPrAddCommand(t *testing.T) {
 			ClientSet: client,
 		}
 
-		cmd := NewPrAddCommand(&p)
+		cmd := NewRegistryAddCommand(&p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--password", "dummy", "--server", "docker.io")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(o, "Private registry"), "unexpected output: %s", o)
@@ -129,7 +129,7 @@ func TestNewPrAddCommand(t *testing.T) {
 			ClientSet: client,
 		}
 
-		cmd := NewPrAddCommand(&p)
+		cmd := NewRegistryAddCommand(&p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--password", "dummy", "--server", "docker.io")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(o, "Private registry"), "unexpected output: %s", o)

--- a/plugins/admin/pkg/command/registry/registry.go
+++ b/plugins/admin/pkg/command/registry/registry.go
@@ -26,7 +26,7 @@ var (
 	DockerJSONName = ".dockerconfigjson"
 )
 
-// AdminRegistryLabels is a set of labels which will add to the registry resources to indicate
+// AdminRegistryLabels is a set of labels which will be added to the registry resources to indicate
 // that these resources are managed by admin registry command.
 var AdminRegistryLabels = map[string]string{
 	pkg.LabelManagedBy: AdminRegistryCmdName,
@@ -37,15 +37,15 @@ type Registry struct {
 	Auths Auths `json:"auths"`
 }
 
-// DockerCred contains actual credentials which are used to pull images
-type DockerCred struct {
+// registryCred contains actual credentials which are used to pull images
+type registryCred struct {
 	Username string `json:"Username"`
 	Password string `json:"Password"`
 	Email    string `json:"Email"`
 }
 
 // Auths is a map of docker credentials indexed by server url
-type Auths map[string]DockerCred
+type Auths map[string]registryCred
 
 // NewPrivateRegistryCmd represents the privateRegistry command
 func NewPrivateRegistryCmd(p *pkg.AdminParams) *cobra.Command {
@@ -62,8 +62,8 @@ kn admin registry add \
   --username=[REGISTRY_USER] \
   --password=[REGISTRY_PASSWORD]`,
 	}
-	privateRegistryCmd.AddCommand(NewPrAddCommand(p))
-	privateRegistryCmd.AddCommand(NewPrRmCommand(p))
+	privateRegistryCmd.AddCommand(NewRegistryAddCommand(p))
+	privateRegistryCmd.AddCommand(NewRegistryRmCommand(p))
 	privateRegistryCmd.InitDefaultHelpCmd()
 	return privateRegistryCmd
 }

--- a/plugins/admin/pkg/command/registry/registry.go
+++ b/plugins/admin/pkg/command/registry/registry.go
@@ -52,7 +52,7 @@ func NewPrivateRegistryCmd(p *pkg.AdminParams) *cobra.Command {
 	var privateRegistryCmd = &cobra.Command{
 		Use:   "registry",
 		Short: "Manage registry",
-		Long: `Manage Service deployment from a registry with credentials
+		Long: `Manage Service deployment from a private registry
 For example:
 
 kn admin registry add \

--- a/plugins/admin/pkg/command/registry/registry.go
+++ b/plugins/admin/pkg/command/registry/registry.go
@@ -19,7 +19,35 @@ import (
 	"knative.dev/client-contrib/plugins/admin/pkg"
 )
 
-// privateRegistryCmd represents the privateRegistry command
+var (
+	// AdminRegistryCmdName is used in the labels to mark the resource this command created
+	AdminRegistryCmdName = "kn-admin-registry"
+	// DockerJSONName is used to represent ".dockerconfigjson" in secret data
+	DockerJSONName = ".dockerconfigjson"
+)
+
+// AdminRegistryLabels is a set of labels which will add to the registry resources to indicate
+// that these resources are managed by admin registry command.
+var AdminRegistryLabels = map[string]string{
+	pkg.LabelManagedBy: AdminRegistryCmdName,
+}
+
+// Registry contains data for secret creation
+type Registry struct {
+	Auths Auths `json:"auths"`
+}
+
+// DockerCred contains actual credentials which are used to pull images
+type DockerCred struct {
+	Username string `json:"Username"`
+	Password string `json:"Password"`
+	Email    string `json:"Email"`
+}
+
+// Auths is a map of docker credentials indexed by server url
+type Auths map[string]DockerCred
+
+// NewPrivateRegistryCmd represents the privateRegistry command
 func NewPrivateRegistryCmd(p *pkg.AdminParams) *cobra.Command {
 	var privateRegistryCmd = &cobra.Command{
 		Use:   "registry",
@@ -35,6 +63,7 @@ kn admin registry add \
   --password=[REGISTRY_PASSWORD]`,
 	}
 	privateRegistryCmd.AddCommand(NewPrAddCommand(p))
+	privateRegistryCmd.AddCommand(NewPrRmCommand(p))
 	privateRegistryCmd.InitDefaultHelpCmd()
 	return privateRegistryCmd
 }

--- a/plugins/admin/pkg/command/registry/registry_test.go
+++ b/plugins/admin/pkg/command/registry/registry_test.go
@@ -23,7 +23,7 @@ import (
 func TestNewPrivateRegistryCmd(t *testing.T) {
 	cmd := NewPrivateRegistryCmd(nil)
 	assert.Check(t, cmd.HasSubCommands(), "cmd registry should have subcommands")
-	assert.Equal(t, 2, len(cmd.Commands()), "registry command should have 2 subcommands")
+	assert.Equal(t, 3, len(cmd.Commands()), "registry command should have 3 subcommands")
 
 	_, _, err := cmd.Find([]string{"add"})
 	assert.NilError(t, err, "registry command should have add subcommand")

--- a/plugins/admin/pkg/command/registry/remove.go
+++ b/plugins/admin/pkg/command/registry/remove.go
@@ -36,14 +36,15 @@ var server string
 // NewRegistryRmCommand represents the remove command
 func NewRegistryRmCommand(p *pkg.AdminParams) *cobra.Command {
 	var registryRmCmd = &cobra.Command{
-		Use:   "remove",
-		Short: "Remove registry settings",
-		Long:  `Remove registry settings by server and username to delete secret and update ServiceAccount`,
+		Use:     "remove",
+		Aliases: []string{"rm"},
+		Short:   "Remove registry settings",
+		Long:    `Remove registry settings by server and username to delete secret and update ServiceAccount`,
 		Example: `
-# remove registry settings
-kn admin registry remove \
-  --username=[REGISTRY_USER] \
-  --server=[REGISTRY_SERVER_URL]`,
+  # To remove registry settings
+  kn admin registry remove \
+    --username=[REGISTRY_USER] \
+    --server=[REGISTRY_SERVER_URL]`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if username == "" {
 				return errors.New("'registry remove' requires the registry username provided with the --username option")

--- a/plugins/admin/pkg/command/registry/remove.go
+++ b/plugins/admin/pkg/command/registry/remove.go
@@ -1,0 +1,148 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/client-contrib/plugins/admin/pkg"
+
+	"github.com/spf13/cobra"
+)
+
+var username string
+var server string
+
+// NewPrRmCommand represents the remove command
+func NewPrRmCommand(p *pkg.AdminParams) *cobra.Command {
+	var prRmCmd = &cobra.Command{
+		Use:   "remove",
+		Short: "Remove registry with credentials",
+		Long: `Remove registry with credentials that used for Service deployment
+For example:
+
+kn admin registry remove \
+  --username=[REGISTRY_USER] \
+  --server=[REGISTRY_SERVER_URL]`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if username == "" {
+				return errors.New("'registry remove' requires the registry username provided with the --username option")
+			}
+			if server == "" {
+				return errors.New("'registry remove' requires the registry server url provided with the --server option")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// get all credential secrets which have the label managed-by=kn-admin-registry
+			secrets, err := p.ClientSet.CoreV1().Secrets("default").List(metav1.ListOptions{
+				LabelSelector: labels.SelectorFromSet(AdminRegistryLabels).String(),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to list secret: %v", err)
+			}
+
+			// filter the secrets with username and server
+			secretsMap := make(map[string]*corev1.Secret)
+			for _, secret := range secrets.Items {
+				registry := Registry{}
+				err = json.Unmarshal(secret.Data[DockerJSONName], &registry)
+				if err != nil {
+					return fmt.Errorf("failed unmarshal secret data '.dockerconfigjson': %v", err)
+				}
+				for secretServer, secretAuth := range registry.Auths {
+					if secretServer == server && secretAuth.Username == username {
+						secretsMap[secret.Name] = &secret
+					}
+				}
+			}
+			if len(secretsMap) == 0 {
+				cmd.Printf("No registry found for server: '%s' and username: '%s'\n", server, username)
+				return nil
+			}
+
+			defaultSa, err := p.ClientSet.CoreV1().ServiceAccounts("default").Get("default", metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to get serviceaccount: %v", err)
+			}
+
+			desiredSa := defaultSa.DeepCopy()
+			imagePullSecrets := []corev1.LocalObjectReference{}
+			for _, ips := range desiredSa.ImagePullSecrets {
+				if _, ok := secretsMap[ips.Name]; !ok {
+					// only store the secrets that do not exist in the map
+					imagePullSecrets = append(imagePullSecrets, ips)
+				}
+
+			}
+
+			desiredSa.ImagePullSecrets = imagePullSecrets
+			_, err = p.ClientSet.CoreV1().ServiceAccounts("default").Update(desiredSa)
+			if err != nil {
+				return fmt.Errorf("failed to remove registry secret in default serviceaccount: %v", err)
+			}
+			cmd.Printf("ImagePullSecrets of ServiceAccount '%s/%s' updated\n", desiredSa.Namespace, desiredSa.Name)
+
+			deleteSecretsErrCh := make(chan error, len(secretsMap))
+			deleteSecrets(cmd, p.ClientSet, secretsMap, deleteSecretsErrCh)
+
+			var deleteSecretsErr error
+			select {
+			case deleteSecretsErr = <-deleteSecretsErrCh:
+				if deleteSecretsErr != nil {
+					break
+				}
+			default:
+			}
+
+			if deleteSecretsErr != nil {
+				return fmt.Errorf("failed to delete secrets: %v", deleteSecretsErr)
+			}
+
+			return nil
+		},
+	}
+
+	prRmCmd.Flags().StringVar(&username, "username", "", "Registry Username")
+	prRmCmd.MarkFlagRequired("username")
+	prRmCmd.Flags().StringVar(&server, "server", "", "Registry Address")
+	prRmCmd.MarkFlagRequired("server")
+	prRmCmd.InitDefaultHelpFlag()
+	return prRmCmd
+}
+
+func deleteSecrets(cmd *cobra.Command, clientset kubernetes.Interface, secretsMap map[string]*corev1.Secret, errCh chan<- error) {
+	w := sync.WaitGroup{}
+	w.Add(len(secretsMap))
+	for _, s := range secretsMap {
+		go func(secret *corev1.Secret) {
+			defer w.Done()
+			err := clientset.CoreV1().Secrets(secret.Namespace).Delete(secret.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				errCh <- fmt.Errorf("failed to delete secret '%s': %v", secret.Name, err)
+			} else {
+				cmd.Printf("Secret '%s/%s' deleted\n", secret.Namespace, secret.Name)
+			}
+		}(s)
+	}
+	w.Wait()
+}

--- a/plugins/admin/pkg/command/registry/remove_test.go
+++ b/plugins/admin/pkg/command/registry/remove_test.go
@@ -30,14 +30,13 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
-func TestNewPrRmCommand(t *testing.T) {
-
+func TestNewRegistryRmCommand(t *testing.T) {
 	t.Run("incompleted args for registry remove", func(t *testing.T) {
 		client := k8sfake.NewSimpleClientset()
 		p := pkg.AdminParams{
 			ClientSet: client,
 		}
-		cmd := NewPrRmCommand(&p)
+		cmd := NewRegistryRmCommand(&p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--username", "")
 		assert.ErrorContains(t, err, "requires the registry username")
@@ -51,7 +50,7 @@ func TestNewPrRmCommand(t *testing.T) {
 		p := pkg.AdminParams{
 			ClientSet: client,
 		}
-		cmd := NewPrRmCommand(&p)
+		cmd := NewRegistryRmCommand(&p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--server", "docker.io")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(o, "No registry found"), "unexpected output: %s", o)
@@ -72,7 +71,7 @@ func TestNewPrRmCommand(t *testing.T) {
 
 		dockerCfg := Registry{
 			Auths: Auths{
-				"docker.io": DockerCred{
+				"docker.io": registryCred{
 					Username: "user",
 					Password: "password",
 					Email:    "email",
@@ -100,7 +99,7 @@ func TestNewPrRmCommand(t *testing.T) {
 			ClientSet: client,
 		}
 
-		cmd := NewPrRmCommand(&p)
+		cmd := NewRegistryRmCommand(&p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--server", "docker.io")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(o, "ImagePullSecrets of ServiceAccount 'default/default' updated"), "unexpected output: %s", o)

--- a/plugins/admin/pkg/command/registry/remove_test.go
+++ b/plugins/admin/pkg/command/registry/remove_test.go
@@ -1,0 +1,124 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"knative.dev/client-contrib/plugins/admin/pkg"
+	"knative.dev/client-contrib/plugins/admin/pkg/testutil"
+
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNewPrRmCommand(t *testing.T) {
+
+	t.Run("incompleted args for registry remove", func(t *testing.T) {
+		client := k8sfake.NewSimpleClientset()
+		p := pkg.AdminParams{
+			ClientSet: client,
+		}
+		cmd := NewPrRmCommand(&p)
+
+		_, err := testutil.ExecuteCommand(cmd, "--username", "")
+		assert.ErrorContains(t, err, "requires the registry username")
+
+		_, err = testutil.ExecuteCommand(cmd, "--username", "dummy", "--server", "")
+		assert.ErrorContains(t, err, "requires the registry server")
+	})
+
+	t.Run("registry not found", func(t *testing.T) {
+		client := k8sfake.NewSimpleClientset()
+		p := pkg.AdminParams{
+			ClientSet: client,
+		}
+		cmd := NewPrRmCommand(&p)
+		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--server", "docker.io")
+		assert.NilError(t, err)
+		assert.Check(t, strings.Contains(o, "No registry found"), "unexpected output: %s", o)
+	})
+
+	t.Run("registry removed successfully", func(t *testing.T) {
+		sa := corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default",
+				Namespace: "default",
+			},
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{
+					Name: "dummy-secret",
+				},
+			},
+		}
+
+		dockerCfg := Registry{
+			Auths: Auths{
+				"docker.io": DockerCred{
+					Username: "user",
+					Password: "password",
+					Email:    "email",
+				},
+			},
+		}
+
+		j, err := json.Marshal(dockerCfg)
+		assert.NilError(t, err)
+
+		secret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-secret",
+				Namespace: "default",
+				Labels: map[string]string{
+					pkg.LabelManagedBy: AdminRegistryCmdName,
+				},
+			},
+			Data: map[string][]byte{
+				".dockerconfigjson": j,
+			},
+		}
+		client := k8sfake.NewSimpleClientset(&sa, &secret)
+		p := pkg.AdminParams{
+			ClientSet: client,
+		}
+
+		cmd := NewPrRmCommand(&p)
+		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--server", "docker.io")
+		assert.NilError(t, err)
+		assert.Check(t, strings.Contains(o, "ImagePullSecrets of ServiceAccount 'default/default' updated"), "unexpected output: %s", o)
+		assert.Check(t, strings.Contains(o, "Secret 'default/dummy-secret' deleted"), "unexpected output: %s", o)
+
+		_, err = client.CoreV1().Secrets("default").Get("dummy-secret", metav1.GetOptions{})
+		assert.ErrorContains(t, err, "not found")
+		saUpdated, err := client.CoreV1().ServiceAccounts("default").Get("default", metav1.GetOptions{})
+		assert.NilError(t, err)
+		isContain := false
+		for _, imagePullSecret := range saUpdated.ImagePullSecrets {
+			if imagePullSecret.Name == "dummy-secret" {
+				isContain = true
+				break
+			}
+		}
+		assert.Check(t, !isContain, "ImagePullSecrets in the updated ServiceAccount should not contain the removed secret")
+
+	})
+
+}

--- a/plugins/admin/pkg/types.go
+++ b/plugins/admin/pkg/types.go
@@ -24,12 +24,17 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// LabelManagedBy is a label name to indicate who is managing this resource
+var LabelManagedBy = "app.kubernetes.io/managed-by"
+
+// AdminParams stores the configs for interacting with kube api
 type AdminParams struct {
 	KubeCfgPath  string
 	ClientConfig clientcmd.ClientConfig
 	ClientSet    kubernetes.Interface
 }
 
+// Initialize generate the clientset for params
 func (params *AdminParams) Initialize() error {
 	if params.ClientSet == nil {
 		restConfig, err := params.RestConfig()


### PR DESCRIPTION
For issue: https://github.com/knative/client-contrib/issues/39

As a Knative administrator, I want to remove registry with credentials for Knative platform through username and server url.

```
For example:
# To remove a registry
kn admin registry remove --username=myusername  --server=docker.io

Usage:
  kn admin registry remove [flags]

Flags:
  -h, --help              help for remove
      --server string     Registry Address
      --username string   Registry Username

Global Flags:
      --config string   config file (default is $HOME/.config/kn/plugins/admin.yaml)
```