### PR TITLE
Improve domain subcommands and some wording suggestions

### DIFF
--- a/plugins/admin/README.adoc
+++ b/plugins/admin/README.adoc
@@ -69,7 +69,7 @@ Manage Service deployment from a private registry
 For example:
 
 kn admin registry add \
-  --secret-name=[SECRET_NAME]
+  --secret=[SECRET_NAME]
   --server=[REGISTRY_SERVER_URL] \
   --email=[REGISTRY_EMAIL] \
   --username=[REGISTRY_USER] \

--- a/plugins/admin/core/root.go
+++ b/plugins/admin/core/root.go
@@ -31,7 +31,6 @@ import (
 var cfgFile string
 
 // rootCmd represents the base command when called without any subcommands
-
 func NewAdminCommand(params ...pkg.AdminParams) *cobra.Command {
 	p := &pkg.AdminParams{}
 	p.Initialize()
@@ -39,13 +38,10 @@ func NewAdminCommand(params ...pkg.AdminParams) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "kn\u00A0admin",
 		Short: "A plugin of kn client to manage Knative",
-		Long: `kn admin: a plugin of kn client to manage Knative for administrators.
+		Long:  `kn admin: a plugin of kn client to manage Knative for administrators`,
 
-For example:
-kn admin domain set - to set Knative route domain
-kn admin registry add - to add registry with credentials
-kn admin autoscaling update - to manage autoscaling config
-`,
+		// disable printing usage when error occurs
+		SilenceUsage: true,
 	}
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/kn/plugins/admin.yaml)")

--- a/plugins/admin/core/root_test.go
+++ b/plugins/admin/core/root_test.go
@@ -15,9 +15,12 @@
 package core
 
 import (
+	"strings"
 	"testing"
 
 	"gotest.tools/assert"
+
+	"knative.dev/client-contrib/plugins/admin/pkg/testutil"
 )
 
 func TestNewAdminCommand(t *testing.T) {
@@ -29,6 +32,7 @@ func TestNewAdminCommand(t *testing.T) {
 			"help",
 			"domain",
 			"registry",
+			"autoscaling",
 		}
 
 		cmd := NewAdminCommand()
@@ -41,4 +45,10 @@ func TestNewAdminCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("make sure usage has kn admin", func(t *testing.T) {
+		cmd := NewAdminCommand()
+		output, err := testutil.ExecuteCommand(cmd)
+		assert.NilError(t, err)
+		assert.Check(t, strings.Contains(output, "Usage:\n  kn\u00a0admin [command]\n"), "invalid usage %q", output)
+	})
 }

--- a/plugins/admin/pkg/command/autoscaling/autoscaling.go
+++ b/plugins/admin/pkg/command/autoscaling/autoscaling.go
@@ -24,7 +24,7 @@ func NewAutoscalingCmd(p *pkg.AdminParams) *cobra.Command {
 	var AutoscalingCmd = &cobra.Command{
 		Use:   "autoscaling",
 		Short: "Manage autoscaling config",
-		Long:  `Manage autoscaling provided by Knative Pod Autoscaler (KPA).`,
+		Long:  `Manage autoscaling provided by Knative Pod Autoscaler (KPA)`,
 	}
 	AutoscalingCmd.AddCommand(NewAutoscalingUpdateCommand(p))
 	AutoscalingCmd.InitDefaultHelpFlag()

--- a/plugins/admin/pkg/command/autoscaling/update.go
+++ b/plugins/admin/pkg/command/autoscaling/update.go
@@ -45,6 +45,7 @@ func NewAutoscalingUpdateCommand(p *pkg.AdminParams) *cobra.Command {
 		Example: `
   # To enable scale-to-zero
   kn admin autoscaling update --scale-to-zero
+
   # To disable scale-to-zero
   kn admin autoscaling update --no-scale-to-zero`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/plugins/admin/pkg/command/domain/domain.go
+++ b/plugins/admin/pkg/command/domain/domain.go
@@ -24,7 +24,7 @@ func NewDomainCmd(p *pkg.AdminParams) *cobra.Command {
 	var domainCmd = &cobra.Command{
 		Use:   "domain",
 		Short: "Manage route domain",
-		Long:  `Manage default route domain or custom route domain for Service with selectors.`,
+		Long:  `Manage default route domain or custom route domain for service(s) with selectors`,
 	}
 	domainCmd.AddCommand(NewDomainSetCommand(p))
 	domainCmd.AddCommand(NewDomainUnSetCommand(p))

--- a/plugins/admin/pkg/command/domain/set.go
+++ b/plugins/admin/pkg/command/domain/set.go
@@ -112,7 +112,7 @@ func NewDomainSetCommand(p *pkg.AdminParams) *cobra.Command {
 func splitByEqualSign(pair string) (string, string, error) {
 	parts := strings.Split(pair, "=")
 	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
-		return "", "", fmt.Errorf("expecting the selector format is 'name=vlue', but given '%s'", pair)
+		return "", "", fmt.Errorf("expecting the selector format 'name=value', found '%s'", pair)
 	}
 	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
 }

--- a/plugins/admin/pkg/command/domain/set_test.go
+++ b/plugins/admin/pkg/command/domain/set_test.go
@@ -96,7 +96,7 @@ func TestNewDomainSetCommand(t *testing.T) {
 
 		v, ok := cm.Data["dummy.domain"]
 		assert.Check(t, ok, "domain key %q should exists", "dummy.domain")
-		assert.Equal(t, "", v, "value of key domain should beempty")
+		assert.Equal(t, "", v, "value of key domain should be empty")
 	})
 
 	t.Run("setting domain config with unchanged value", func(t *testing.T) {
@@ -149,7 +149,7 @@ func TestNewDomainSetCommand(t *testing.T) {
 
 		v, ok := cm.Data["dummy.domain"]
 		assert.Check(t, ok, "domain key %q should exists", "dummy.domain")
-		assert.Equal(t, "", v, "value of key domain should beempty")
+		assert.Equal(t, "", v, "value of key domain should be empty")
 	})
 
 	t.Run("adding domain config with selector", func(t *testing.T) {
@@ -187,6 +187,26 @@ func TestNewDomainSetCommand(t *testing.T) {
 		v, ok = s.Selector["app"]
 		assert.Check(t, ok, "key %q should exist", "app")
 		assert.Equal(t, "dummy", v)
+	})
+
+	t.Run("adding domain config with invalid selector", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configDomain,
+				Namespace: knativeServing,
+			},
+			Data: map[string]string{
+				"foo.bar": "",
+			},
+		}
+		client := k8sfake.NewSimpleClientset(cm)
+		p := pkg.AdminParams{
+			ClientSet: client,
+		}
+		cmd := NewDomainSetCommand(&p)
+
+		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain", "--selector", "app")
+		assert.ErrorContains(t, err, "expecting the selector format is 'name=vlue', but given 'app'", err)
 	})
 }
 

--- a/plugins/admin/pkg/command/domain/set_test.go
+++ b/plugins/admin/pkg/command/domain/set_test.go
@@ -206,7 +206,7 @@ func TestNewDomainSetCommand(t *testing.T) {
 		cmd := NewDomainSetCommand(&p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain", "--selector", "app")
-		assert.ErrorContains(t, err, "expecting the selector format is 'name=vlue', but given 'app'", err)
+		assert.ErrorContains(t, err, "expecting the selector format 'name=value', found 'app'", err)
 	})
 }
 

--- a/plugins/admin/pkg/command/domain/unset.go
+++ b/plugins/admin/pkg/command/domain/unset.go
@@ -18,9 +18,8 @@ import (
 	"errors"
 	"fmt"
 
-	"knative.dev/client-contrib/plugins/admin/pkg/command/utils"
-
 	"knative.dev/client-contrib/plugins/admin/pkg"
+	"knative.dev/client-contrib/plugins/admin/pkg/command/utils"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -32,7 +31,7 @@ func NewDomainUnSetCommand(p *pkg.AdminParams) *cobra.Command {
 	domainUnSetCommand := &cobra.Command{
 		Use:   "unset",
 		Short: "Unset route domain",
-		Long:  `Unset Knative route domain for service`,
+		Long:  `Unset Knative route domain for service(s)`,
 		Example: `
   # To unset a route domain
   kn admin domain unset --custom-domain mydomain.com`,

--- a/plugins/admin/pkg/command/registry/add.go
+++ b/plugins/admin/pkg/command/registry/add.go
@@ -46,7 +46,7 @@ func NewRegistryAddCommand(p *pkg.AdminParams) *cobra.Command {
 		Example: `
   # add registry with credentials
   kn admin registry add \
-    --secret-name=[SECRET_NAME]
+    --secret=[SECRET_NAME]
     --server=[REGISTRY_SERVER_URL] \
     --email=[REGISTRY_EMAIL] \
     --username=[REGISTRY_USER] \
@@ -117,7 +117,7 @@ func NewRegistryAddCommand(p *pkg.AdminParams) *cobra.Command {
 		},
 	}
 
-	registryAddCmd.Flags().StringVar(&registryFlags.SecretName, "secret-name", "secret-registry", "Registry Secret Name")
+	registryAddCmd.Flags().StringVar(&registryFlags.SecretName, "secret", "secret-registry", "Registry Secret Name")
 	registryAddCmd.Flags().StringVar(&registryFlags.Server, "server", "", "Registry Address")
 	registryAddCmd.MarkFlagRequired("server")
 	registryAddCmd.Flags().StringVar(&registryFlags.Email, "email", "user@default.email.com", "Registry Email")

--- a/plugins/admin/pkg/command/registry/add.go
+++ b/plugins/admin/pkg/command/registry/add.go
@@ -42,7 +42,7 @@ func NewRegistryAddCommand(p *pkg.AdminParams) *cobra.Command {
 	var registryAddCmd = &cobra.Command{
 		Use:   "add",
 		Short: "Add registry with credentials",
-		Long:  `Add registry with credentials to enable service deployment from it`,
+		Long:  `Add registry with credentials and enable service deployments from this registry`,
 		Example: `
   # add registry with credentials
   kn admin registry add \

--- a/plugins/admin/pkg/command/registry/add.go
+++ b/plugins/admin/pkg/command/registry/add.go
@@ -42,7 +42,7 @@ func NewRegistryAddCommand(p *pkg.AdminParams) *cobra.Command {
 	var registryAddCmd = &cobra.Command{
 		Use:   "add",
 		Short: "Add registry with credentials",
-		Long:  `Add registry with credentials to enable Service deployment from it`,
+		Long:  `Add registry with credentials to enable service deployment from it`,
 		Example: `
   # add registry with credentials
   kn admin registry add \

--- a/plugins/admin/pkg/command/registry/registry.go
+++ b/plugins/admin/pkg/command/registry/registry.go
@@ -52,7 +52,7 @@ func NewPrivateRegistryCmd(p *pkg.AdminParams) *cobra.Command {
 	var privateRegistryCmd = &cobra.Command{
 		Use:   "registry",
 		Short: "Manage registry",
-		Long:  `Manage service deployment from a registry with credentials`,
+		Long:  `Manage registry used by Knative service deployment`,
 	}
 	privateRegistryCmd.AddCommand(NewRegistryAddCommand(p))
 	privateRegistryCmd.AddCommand(NewRegistryRmCommand(p))

--- a/plugins/admin/pkg/command/registry/registry.go
+++ b/plugins/admin/pkg/command/registry/registry.go
@@ -52,7 +52,7 @@ func NewPrivateRegistryCmd(p *pkg.AdminParams) *cobra.Command {
 	var privateRegistryCmd = &cobra.Command{
 		Use:   "registry",
 		Short: "Manage registry",
-		Long:  `Manage Service deployment from a registry with credentials`,
+		Long:  `Manage service deployment from a registry with credentials`,
 	}
 	privateRegistryCmd.AddCommand(NewRegistryAddCommand(p))
 	privateRegistryCmd.AddCommand(NewRegistryRmCommand(p))


### PR DESCRIPTION
This PR is mainly used to address the issue: [#41](https://github.com/knative/client-contrib/issues/41) and some wording suggestions from PR: [#40](https://github.com/knative/client-contrib/pull/40):
1. Return error for invalid ```--selector``` value when using ```domain set``` subcommand
2. Add UT for **adding domain with invalid selector**
3. Improve help and error message for ```domain set``` subcommand
4. Remove **For example: xxx** from admin root command
5. Set ```SilenceUsage: true``` for admin root command to keep the same behaivour as kn client
6. Improve wording according to suggestions from: [#40 (comment)](https://github.com/knative/client-contrib/pull/40#discussion_r444649879)