### PR TITLE
[source-kafka] Fix error handling for kubeconfig

### DIFF
--- a/plugins/source-kafka/OWNERS
+++ b/plugins/source-kafka/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- daisy-ycguo

--- a/plugins/source-kafka/go.mod
+++ b/plugins/source-kafka/go.mod
@@ -3,7 +3,7 @@ module knative.dev/client-contrib/plugins/source-kafka
 go 1.14
 
 require (
-	github.com/maximilien/kn-source-pkg v0.4.8-0.20200604003102-1caadf074019
+	github.com/maximilien/kn-source-pkg v0.4.10
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	gotest.tools v2.2.0+incompatible

--- a/plugins/source-kafka/go.sum
+++ b/plugins/source-kafka/go.sum
@@ -247,8 +247,8 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
-github.com/maximilien/kn-source-pkg v0.4.8-0.20200604003102-1caadf074019 h1:d6AN/Z2e1EkK2kcbdV8pSh6SaG8EVOxo9shrsh4uZ3o=
-github.com/maximilien/kn-source-pkg v0.4.8-0.20200604003102-1caadf074019/go.mod h1:zsncYNwuLplBjtxr5vPZ0+2OSpxwJLN+8oMaJVpqCTE=
+github.com/maximilien/kn-source-pkg v0.4.10 h1:14Sz7eCmo88Ib95AT2HMl04AgK8DPl0gChQ2z3njSC4=
+github.com/maximilien/kn-source-pkg v0.4.10/go.mod h1:zsncYNwuLplBjtxr5vPZ0+2OSpxwJLN+8oMaJVpqCTE=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=

--- a/plugins/source-kafka/pkg/client/client.go
+++ b/plugins/source-kafka/pkg/client/client.go
@@ -28,23 +28,24 @@ import (
 )
 
 type kafkaSourceClient struct {
-	kafkaSourceParams *types.KafkaSourceParams
-	client            clientv1alpha1.SourcesV1alpha1Interface
 	namespace         string
+	kafkaSourceParams *types.KafkaSourceParams
 	knSourceClient    sourcetypes.KnSourceClient
+	client            clientv1alpha1.SourcesV1alpha1Interface
 }
 
 // NewKafkaSourceClient is to create a KafkaSourceClient
-func NewKafkaSourceClient(kafkaParams *types.KafkaSourceParams, c clientv1alpha1.SourcesV1alpha1Interface, ns string) types.KafkaSourceClient {
-	if c == nil {
-		c, _ = kafkaParams.NewSourcesClient()
+func NewKafkaSourceClient(kafkaParams *types.KafkaSourceParams, restConfig *rest.Config, ns string) (types.KafkaSourceClient, error) {
+	kafkaClient, err := kafkaParams.NewSourcesClient()
+	if err != nil {
+		return nil, knerrors.GetError(err)
 	}
 	return &kafkaSourceClient{
 		kafkaSourceParams: kafkaParams,
-		client:            c,
 		namespace:         ns,
-		knSourceClient:    sourceclient.NewKnSourceClient(kafkaParams.KnSourceParams, ns),
-	}
+		knSourceClient:    sourceclient.NewKnSourceClient(kafkaParams.KnSourceParams, restConfig, ns),
+		client:            kafkaClient,
+	}, nil
 }
 
 // RestConfig the REST cconfig

--- a/plugins/source-kafka/pkg/client/client_fake.go
+++ b/plugins/source-kafka/pkg/client/client_fake.go
@@ -25,7 +25,8 @@ import (
 )
 
 // NewFakeKafkaSourceClient is to create a fake KafkaSourceClient to test
-func NewFakeKafkaSourceClient(kafkaParams *types.KafkaSourceParams, ns string) types.KafkaSourceClient {
+func NewFakeKafkaSourceClient(ns string) types.KafkaSourceClient {
+	kafkaParams := NewFakeKafkaSourceParams()
 	knFakeSourceClient := &typesfakes.FakeKnSourceClient{}
 	knFakeSourceClient.KnSourceParamsReturns(kafkaParams.KnSourceParams)
 	knFakeSourceClient.NamespaceReturns(ns)

--- a/plugins/source-kafka/pkg/client/client_test.go
+++ b/plugins/source-kafka/pkg/client/client_test.go
@@ -22,29 +22,29 @@ import (
 )
 
 func TestKafkaSourceClient(t *testing.T) {
-	knSourceClient := NewFakeKafkaSourceClient(NewFakeKafkaSourceParams(), "fake-namespace")
+	knSourceClient := NewFakeKafkaSourceClient("fake-namespace")
 	assert.Assert(t, knSourceClient != nil)
 }
 
 func TestClient_KnSourceParams(t *testing.T) {
-	fakeKafkaParams := NewFakeKafkaSourceParams()
-	knSourceClient := NewFakeKafkaSourceClient(fakeKafkaParams, "fake-namespace")
+	knSourceClient := NewFakeKafkaSourceClient("fake-namespace")
+	fakeKafkaParams := knSourceClient.KafkaSourceParams()
 	assert.Equal(t, knSourceClient.KnSourceParams(), fakeKafkaParams.KnSourceParams)
 }
 
 func TestNamespace(t *testing.T) {
-	knSourceClient := NewFakeKafkaSourceClient(NewFakeKafkaSourceParams(), "fake-namespace")
+	knSourceClient := NewFakeKafkaSourceClient("fake-namespace")
 	assert.Equal(t, knSourceClient.Namespace(), "fake-namespace")
 }
 func TestCreateKafka(t *testing.T) {
-	cli := NewFakeKafkaSourceClient(NewFakeKafkaSourceParams(), "fake-namespace")
+	cli := NewFakeKafkaSourceClient("fake-namespace")
 	objNew := newKafkaSource("samplekafka")
 	err := cli.CreateKafkaSource(objNew)
 	assert.NilError(t, err)
 }
 
 func TestDeleteKafka(t *testing.T) {
-	cli := NewFakeKafkaSourceClient(NewFakeKafkaSourceParams(), "fake-namespace")
+	cli := NewFakeKafkaSourceClient("fake-namespace")
 	objNew := newKafkaSource("samplekafka")
 	err := cli.CreateKafkaSource(objNew)
 	assert.NilError(t, err)

--- a/plugins/source-kafka/pkg/factories/boilerplate.go
+++ b/plugins/source-kafka/pkg/factories/boilerplate.go
@@ -1,0 +1,76 @@
+// Copyright © 2018 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package factories
+
+import (
+	sourcetypes "github.com/maximilien/kn-source-pkg/pkg/types"
+	"k8s.io/client-go/rest"
+	"knative.dev/client-contrib/plugins/source-kafka/pkg/types"
+)
+
+// source_factory
+
+func (f *kafkaClientFactory) KafkaSourceClient() types.KafkaSourceClient {
+	return f.kafkaSourceClient
+}
+
+func (f *kafkaClientFactory) KnSourceParams() *sourcetypes.KnSourceParams {
+	return f.CreateKnSourceParams()
+}
+
+func (f *kafkaClientFactory) CreateKnSourceParams() *sourcetypes.KnSourceParams {
+	if f.kafkaSourceParams == nil {
+		f.initKafkaSourceParams()
+	}
+	return f.kafkaSourceParams.KnSourceParams
+}
+
+func (f *kafkaClientFactory) CreateKnSourceClient(restConfig *rest.Config, namespace string) sourcetypes.KnSourceClient {
+	f.CreateKafkaSourceClient(restConfig, namespace)
+	return f.KafkaSourceClient()
+}
+
+// rune_factory
+
+func (f *kafkaSourceRunEFactory) KnSourceParams() *sourcetypes.KnSourceParams {
+	return f.KafkaSourceFactory().KnSourceParams()
+}
+
+func (f *kafkaSourceRunEFactory) KnSourceClient(restConfig *rest.Config, namespace string) sourcetypes.KnSourceClient {
+	return f.KafkaSourceFactory().CreateKnSourceClient(restConfig, namespace)
+}
+
+func (f *kafkaSourceRunEFactory) KnSourceFactory() sourcetypes.KnSourceFactory {
+	return f.kafkaSourceFactory
+}
+
+// flags_factory
+
+func (f *kafkaSourceFlagsFactory) KnSourceFactory() sourcetypes.KnSourceFactory {
+	return f.kafkaSourceFactory
+}
+
+func (f *kafkaSourceFlagsFactory) KnSourceParams() *sourcetypes.KnSourceParams {
+	return f.kafkaSourceFactory.KnSourceParams()
+}
+
+// command_factory
+func (f *kafkaSourceCommandFactory) KnSourceFactory() sourcetypes.KnSourceFactory {
+	return f.kafkaSourceFactory
+}
+
+func (f *kafkaSourceCommandFactory) KnSourceParams() *sourcetypes.KnSourceParams {
+	return f.kafkaSourceFactory.KnSourceParams()
+}

--- a/plugins/source-kafka/pkg/factories/boilerplate_test.go
+++ b/plugins/source-kafka/pkg/factories/boilerplate_test.go
@@ -1,0 +1,51 @@
+// Copyright © 2020 The Knative Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package factories
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestKafkaCreateKnSourceParams(t *testing.T) {
+	factory := NewFakeKafkaSourceFactory("fake-namespace")
+
+	knSourceParams := factory.KnSourceParams()
+	assert.Assert(t, knSourceParams != nil)
+
+	knSourceParams = factory.CreateKnSourceParams()
+	assert.Equal(t, factory.KnSourceParams(), knSourceParams)
+}
+
+func TestRunEFactory_KnSourceParams(t *testing.T) {
+	runEFactory := NewFakeKafkaSourceRunEFactory("fake_namespace")
+	assert.Assert(t, runEFactory.KafkaSourceFactory().KnSourceParams() != nil)
+}
+
+func TestRunEFactory_KnSourceFactory(t *testing.T) {
+	runEFactory := NewFakeKafkaSourceRunEFactory("fake_namespace")
+	assert.Assert(t, runEFactory.KnSourceFactory() != nil)
+}
+
+func TestFlagsFactory_KnSourceFactory(t *testing.T) {
+	flagsFactory := createKafkaSourceFlagsFactory()
+	assert.Assert(t, flagsFactory.KnSourceFactory() != nil)
+}
+
+func TestCommand_KnSourceFactory(t *testing.T) {
+	commandFactory := createKafkaSourceCommandFactory()
+	assert.Assert(t, commandFactory.KnSourceFactory() != nil)
+}

--- a/plugins/source-kafka/pkg/factories/command_factory.go
+++ b/plugins/source-kafka/pkg/factories/command_factory.go
@@ -35,20 +35,12 @@ func NewKafkaSourceCommandFactory(kafkaFactory types.KafkaSourceFactory) types.K
 	}
 }
 
-func (f *kafkaSourceCommandFactory) KnSourceFactory() sourcetypes.KnSourceFactory {
-	return f.kafkaSourceFactory
-}
-
 func (f *kafkaSourceCommandFactory) KafkaSourceFactory() types.KafkaSourceFactory {
 	return f.kafkaSourceFactory
 }
 
 func (f *kafkaSourceCommandFactory) KafkaSourceParams() *types.KafkaSourceParams {
 	return f.kafkaSourceFactory.KafkaSourceParams()
-}
-
-func (f *kafkaSourceCommandFactory) KnSourceParams() *sourcetypes.KnSourceParams {
-	return f.kafkaSourceFactory.KnSourceParams()
 }
 
 func (f *kafkaSourceCommandFactory) SourceCommand() *cobra.Command {

--- a/plugins/source-kafka/pkg/factories/command_factory_test.go
+++ b/plugins/source-kafka/pkg/factories/command_factory_test.go
@@ -23,43 +23,31 @@ import (
 
 func TestNewKafkaSourceCommandFactory(t *testing.T) {
 	commandFactory := createKafkaSourceCommandFactory()
-
 	assert.Assert(t, commandFactory != nil)
-}
-
-func TestCommand_KnSourceFactory(t *testing.T) {
-	commandFactory := createKafkaSourceCommandFactory()
-
-	assert.Assert(t, commandFactory.KnSourceFactory() != nil)
 }
 
 func TestSourceCommand(t *testing.T) {
 	commandFactory := createKafkaSourceCommandFactory()
-
 	assert.Assert(t, commandFactory.SourceCommand() != nil)
 }
 
 func TestCreateCommand(t *testing.T) {
 	commandFactory := createKafkaSourceCommandFactory()
-
 	assert.Assert(t, commandFactory.CreateCommand() != nil)
 }
 
 func TestDeleteCommand(t *testing.T) {
 	commandFactory := createKafkaSourceCommandFactory()
-
 	assert.Assert(t, commandFactory.DeleteCommand() != nil)
 }
 
 func TestUpdateCommand(t *testing.T) {
 	commandFactory := createKafkaSourceCommandFactory()
-
 	assert.Assert(t, commandFactory.UpdateCommand() == nil)
 }
 
 func TestDescribeCommand(t *testing.T) {
 	commandFactory := createKafkaSourceCommandFactory()
-
 	assert.Assert(t, commandFactory.DescribeCommand() != nil)
 }
 

--- a/plugins/source-kafka/pkg/factories/flags_factory.go
+++ b/plugins/source-kafka/pkg/factories/flags_factory.go
@@ -35,14 +35,6 @@ func NewKafkaSourceFlagsFactory(kafkaFactory types.KafkaSourceFactory) types.Kaf
 	}
 }
 
-func (f *kafkaSourceFlagsFactory) KnSourceFactory() sourcetypes.KnSourceFactory {
-	return f.kafkaSourceFactory
-}
-
-func (f *kafkaSourceFlagsFactory) KnSourceParams() *sourcetypes.KnSourceParams {
-	return f.kafkaSourceFactory.KnSourceParams()
-}
-
 func (f *kafkaSourceFlagsFactory) KafkaSourceParams() *types.KafkaSourceParams {
 	return f.kafkaSourceFactory.KafkaSourceParams()
 }

--- a/plugins/source-kafka/pkg/factories/flags_factory_test.go
+++ b/plugins/source-kafka/pkg/factories/flags_factory_test.go
@@ -24,14 +24,11 @@ import (
 
 func TestNewKafkaSourceFlagsFactory(t *testing.T) {
 	flagsFactory := createKafkaSourceFlagsFactory()
-
 	assert.Assert(t, flagsFactory != nil)
 }
 
-func TestFlagsFactory_KnSourceFactory(t *testing.T) {
+func TestFlagsFactory_KafkaSourceFactory(t *testing.T) {
 	flagsFactory := createKafkaSourceFlagsFactory()
-
-	assert.Assert(t, flagsFactory.KnSourceFactory() != nil)
 	assert.Equal(t, flagsFactory.KafkaSourceFactory(), flagsFactory.KafkaSourceFactory())
 }
 

--- a/plugins/source-kafka/pkg/factories/rune_factory_test.go
+++ b/plugins/source-kafka/pkg/factories/rune_factory_test.go
@@ -18,32 +18,29 @@ import (
 	"testing"
 
 	"gotest.tools/assert"
+	"k8s.io/client-go/rest"
 )
 
 func TestNewKafkaSourceRunEFactory(t *testing.T) {
 	runEFactory := NewFakeKafkaSourceRunEFactory("fake_namespace")
-
 	assert.Assert(t, runEFactory != nil)
 }
 
 func TestRunEFactory_KafkaSourceParams(t *testing.T) {
 	runEFactory := NewFakeKafkaSourceRunEFactory("fake_namespace")
-
-	assert.Assert(t, runEFactory.KafkaSourceFactory().KnSourceParams() != nil)
 	assert.Assert(t, runEFactory.KafkaSourceFactory().KafkaSourceParams() != nil)
 }
 
 func TestRunEFactory_KafkaSourceFactory(t *testing.T) {
 	runEFactory := NewFakeKafkaSourceRunEFactory("fake_namespace")
-
-	assert.Assert(t, runEFactory.KnSourceFactory() != nil)
 	assert.Assert(t, runEFactory.KafkaSourceFactory() != nil)
 }
 
 func TestRunEFactory_KafkaSourceClient(t *testing.T) {
 	runEFactory := NewFakeKafkaSourceRunEFactory("fake_namespace")
-	knSourceClient := runEFactory.KafkaSourceClient("fake_namespace")
+	knSourceClient, err := runEFactory.KafkaSourceClient(&rest.Config{}, "fake_namespace")
 	assert.Assert(t, knSourceClient != nil)
+	assert.Assert(t, err == nil)
 }
 
 func TestCreateRunE(t *testing.T) {

--- a/plugins/source-kafka/pkg/factories/source_factory_test.go
+++ b/plugins/source-kafka/pkg/factories/source_factory_test.go
@@ -18,22 +18,13 @@ import (
 	"testing"
 
 	"gotest.tools/assert"
+	"k8s.io/client-go/rest"
 )
 
 func TestNewKafkaSourceFactory(t *testing.T) {
 	factory := NewFakeKafkaSourceFactory("fake-namespace")
 
 	assert.Assert(t, factory != nil)
-}
-
-func TestKafkaCreateKnSourceParams(t *testing.T) {
-	factory := NewFakeKafkaSourceFactory("fake-namespace")
-
-	knSourceParams := factory.KnSourceParams()
-	assert.Assert(t, knSourceParams != nil)
-
-	knSourceParams = factory.CreateKnSourceParams()
-	assert.Equal(t, factory.KnSourceParams(), knSourceParams)
 }
 
 func TestCreateKafkaSourceParams(t *testing.T) {
@@ -46,10 +37,10 @@ func TestCreateKafkaSourceParams(t *testing.T) {
 
 func TestCreateKafkaSourceClient(t *testing.T) {
 	factory := NewFakeKafkaSourceFactory("fake-namespace")
-	client := factory.CreateKafkaSourceClient("fake-namespace")
+	client, _ := factory.CreateKafkaSourceClient(&rest.Config{}, "fake-namespace")
 
 	assert.Assert(t, client != nil)
 	assert.Equal(t, factory.KafkaSourceClient(), client)
-	assert.Equal(t, factory.CreateKnSourceClient("fake-namespace"), client)
+	assert.Equal(t, factory.CreateKnSourceClient(&rest.Config{}, "fake-namespace"), client)
 	assert.Equal(t, client.Namespace(), "fake-namespace")
 }

--- a/plugins/source-kafka/pkg/types/interfaces.go
+++ b/plugins/source-kafka/pkg/types/interfaces.go
@@ -18,10 +18,12 @@ import (
 	v1alpha1 "knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1"
 
 	sourcetypes "github.com/maximilien/kn-source-pkg/pkg/types"
+	"k8s.io/client-go/rest"
 )
 
 type KafkaSourceClient interface {
 	sourcetypes.KnSourceClient
+	KafkaSourceParams() *KafkaSourceParams
 	CreateKafkaSource(kafkaSource *v1alpha1.KafkaSource) error
 	DeleteKafkaSource(name string) error
 	GetKafkaSource(name string) (*v1alpha1.KafkaSource, error)
@@ -33,7 +35,7 @@ type KafkaSourceFactory interface {
 	KafkaSourceParams() *KafkaSourceParams
 	KafkaSourceClient() KafkaSourceClient
 
-	CreateKafkaSourceClient(namespace string) KafkaSourceClient
+	CreateKafkaSourceClient(restConfig *rest.Config, namespace string) (KafkaSourceClient, error)
 	CreateKafkaSourceParams() *KafkaSourceParams
 }
 
@@ -53,5 +55,5 @@ type KafkaSourceRunEFactory interface {
 	sourcetypes.RunEFactory
 
 	KafkaSourceFactory() KafkaSourceFactory
-	KafkaSourceClient(namespace string) KafkaSourceClient
+	KafkaSourceClient(restConfig *rest.Config, namespace string) (KafkaSourceClient, error)
 }

--- a/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/client/client.go
+++ b/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/client/client.go
@@ -15,8 +15,6 @@
 package client
 
 import (
-	"fmt"
-
 	"github.com/maximilien/kn-source-pkg/pkg/types"
 
 	"k8s.io/client-go/rest"
@@ -29,12 +27,7 @@ type knSourceClient struct {
 }
 
 // NewKnSourceClient creates a new KnSourceClient with parameters and namespace
-func NewKnSourceClient(knSourceParams *types.KnSourceParams, namespace string) types.KnSourceClient {
-	restConfig, err := knSourceParams.RestConfig()
-	if err != nil {
-		panic(fmt.Sprintf("Could not create Kn source client, error: %s", err.Error()))
-	}
-
+func NewKnSourceClient(knSourceParams *types.KnSourceParams, restConfig *rest.Config, namespace string) types.KnSourceClient {
 	return &knSourceClient{
 		knSourceParams: knSourceParams,
 		namespace:      namespace,

--- a/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/factories/boilerplate.go
+++ b/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/factories/boilerplate.go
@@ -14,7 +14,10 @@
 
 package factories
 
-import "github.com/maximilien/kn-source-pkg/pkg/types"
+import (
+	"github.com/maximilien/kn-source-pkg/pkg/types"
+	"k8s.io/client-go/rest"
+)
 
 // KnSourceFactory
 
@@ -44,6 +47,6 @@ func (f *DefautRunEFactory) KnSourceFactory() types.KnSourceFactory {
 	return f.knSourceFactory
 }
 
-func (f *DefautRunEFactory) KnSourceClient(namespace string) types.KnSourceClient {
-	return f.knSourceFactory.CreateKnSourceClient(namespace)
+func (f *DefautRunEFactory) KnSourceClient(restConfig *rest.Config, namespace string) types.KnSourceClient {
+	return f.knSourceFactory.CreateKnSourceClient(restConfig, namespace)
 }

--- a/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/factories/kn_source_factory.go
+++ b/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/factories/kn_source_factory.go
@@ -17,6 +17,7 @@ package factories
 import (
 	"github.com/maximilien/kn-source-pkg/pkg/client"
 	"github.com/maximilien/kn-source-pkg/pkg/types"
+	"k8s.io/client-go/rest"
 
 	"knative.dev/client/pkg/kn/commands/flags"
 )
@@ -27,7 +28,7 @@ type DefautKnSourceFactory struct {
 	knSourceClientFunc KnSourceClientFunc
 }
 
-type KnSourceClientFunc = func(knSourceParams *types.KnSourceParams, namespace string) types.KnSourceClient
+type KnSourceClientFunc = func(knSourceParams *types.KnSourceParams, restConfig *rest.Config, namespace string) types.KnSourceClient
 
 func NewDefaultKnSourceFactory() types.KnSourceFactory {
 	return &DefautKnSourceFactory{
@@ -43,6 +44,6 @@ func (f *DefautKnSourceFactory) CreateKnSourceParams() *types.KnSourceParams {
 	return f.knSourceParams
 }
 
-func (f *DefautKnSourceFactory) CreateKnSourceClient(namespace string) types.KnSourceClient {
-	return f.knSourceClientFunc(f.knSourceParams, namespace)
+func (f *DefautKnSourceFactory) CreateKnSourceClient(restConfig *rest.Config, namespace string) types.KnSourceClient {
+	return f.knSourceClientFunc(f.knSourceParams, restConfig, namespace)
 }

--- a/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/factories/rune_factory.go
+++ b/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/factories/rune_factory.go
@@ -38,10 +38,13 @@ func (f *DefautRunEFactory) CreateRunE() types.RunE {
 		if err != nil {
 			return err
 		}
-		knSourceClient := f.KnSourceClient(namespace)
+
+		restConfig, err := f.KnSourceFactory().KnSourceParams().KnParams.RestConfig()
 		if err != nil {
-			return fmt.Errorf("could not access KnSourceClient for command %s", cmd.Name())
+			return err
 		}
+
+		knSourceClient := f.KnSourceClient(restConfig, namespace)
 
 		fmt.Printf("%s RunE called: args: %#v, client: %#v, sink: %s\n", cmd.Name(), args, knSourceClient, knSourceClient.KnSourceParams().SinkFlag)
 
@@ -55,10 +58,13 @@ func (f *DefautRunEFactory) DeleteRunE() types.RunE {
 		if err != nil {
 			return err
 		}
-		knSourceClient := f.KnSourceClient(namespace)
+
+		restConfig, err := f.KnSourceFactory().KnSourceParams().KnParams.RestConfig()
 		if err != nil {
-			return fmt.Errorf("could not access KnSourceClient for command %s", cmd.Name())
+			return err
 		}
+
+		knSourceClient := f.KnSourceClient(restConfig, namespace)
 
 		fmt.Printf("%s RunE called: args: %#v, client: %#v, sink: %s\n", cmd.Name(), args, knSourceClient, knSourceClient.KnSourceParams().SinkFlag)
 
@@ -72,10 +78,13 @@ func (f *DefautRunEFactory) UpdateRunE() types.RunE {
 		if err != nil {
 			return err
 		}
-		knSourceClient := f.KnSourceClient(namespace)
+
+		restConfig, err := f.KnSourceFactory().KnSourceParams().KnParams.RestConfig()
 		if err != nil {
-			return fmt.Errorf("could not access KnSourceClient for command %s", cmd.Name())
+			return err
 		}
+
+		knSourceClient := f.KnSourceClient(restConfig, namespace)
 
 		fmt.Printf("%s RunE called: args: %#v, client: %#v, sink: %s\n", cmd.Name(), args, knSourceClient, knSourceClient.KnSourceParams().SinkFlag)
 
@@ -89,10 +98,13 @@ func (f *DefautRunEFactory) DescribeRunE() types.RunE {
 		if err != nil {
 			return err
 		}
-		knSourceClient := f.KnSourceClient(namespace)
+
+		restConfig, err := f.KnSourceFactory().KnSourceParams().KnParams.RestConfig()
 		if err != nil {
-			return fmt.Errorf("could not access KnSourceClient for command %s", cmd.Name())
+			return err
 		}
+
+		knSourceClient := f.KnSourceClient(restConfig, namespace)
 
 		fmt.Printf("%s RunE called: args: %#v, client: %#v, sink: %s\n", cmd.Name(), args, knSourceClient, knSourceClient.KnSourceParams().SinkFlag)
 

--- a/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/types/interfaces.go
+++ b/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/types/interfaces.go
@@ -40,7 +40,7 @@ type KnSourceFactory interface {
 	KnSourceParams() *KnSourceParams
 
 	CreateKnSourceParams() *KnSourceParams
-	CreateKnSourceClient(namespace string) KnSourceClient
+	CreateKnSourceClient(restConfig *rest.Config, namespace string) KnSourceClient
 }
 
 // CommandFactory is the factory for cobra.Command objects
@@ -76,5 +76,5 @@ type RunEFactory interface {
 	DescribeRunE() RunE
 
 	KnSourceFactory() KnSourceFactory
-	KnSourceClient(namespace string) KnSourceClient
+	KnSourceClient(restConfig *rest.Config, namespace string) KnSourceClient
 }

--- a/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/types/typesfakes/fake_kn_source_factory.go
+++ b/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/types/typesfakes/fake_kn_source_factory.go
@@ -5,13 +5,15 @@ import (
 	"sync"
 
 	"github.com/maximilien/kn-source-pkg/pkg/types"
+	"k8s.io/client-go/rest"
 )
 
 type FakeKnSourceFactory struct {
-	CreateKnSourceClientStub        func(string) types.KnSourceClient
+	CreateKnSourceClientStub        func(*rest.Config, string) types.KnSourceClient
 	createKnSourceClientMutex       sync.RWMutex
 	createKnSourceClientArgsForCall []struct {
-		arg1 string
+		arg1 *rest.Config
+		arg2 string
 	}
 	createKnSourceClientReturns struct {
 		result1 types.KnSourceClient
@@ -43,16 +45,17 @@ type FakeKnSourceFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeKnSourceFactory) CreateKnSourceClient(arg1 string) types.KnSourceClient {
+func (fake *FakeKnSourceFactory) CreateKnSourceClient(arg1 *rest.Config, arg2 string) types.KnSourceClient {
 	fake.createKnSourceClientMutex.Lock()
 	ret, specificReturn := fake.createKnSourceClientReturnsOnCall[len(fake.createKnSourceClientArgsForCall)]
 	fake.createKnSourceClientArgsForCall = append(fake.createKnSourceClientArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("CreateKnSourceClient", []interface{}{arg1})
+		arg1 *rest.Config
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("CreateKnSourceClient", []interface{}{arg1, arg2})
 	fake.createKnSourceClientMutex.Unlock()
 	if fake.CreateKnSourceClientStub != nil {
-		return fake.CreateKnSourceClientStub(arg1)
+		return fake.CreateKnSourceClientStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -67,17 +70,17 @@ func (fake *FakeKnSourceFactory) CreateKnSourceClientCallCount() int {
 	return len(fake.createKnSourceClientArgsForCall)
 }
 
-func (fake *FakeKnSourceFactory) CreateKnSourceClientCalls(stub func(string) types.KnSourceClient) {
+func (fake *FakeKnSourceFactory) CreateKnSourceClientCalls(stub func(*rest.Config, string) types.KnSourceClient) {
 	fake.createKnSourceClientMutex.Lock()
 	defer fake.createKnSourceClientMutex.Unlock()
 	fake.CreateKnSourceClientStub = stub
 }
 
-func (fake *FakeKnSourceFactory) CreateKnSourceClientArgsForCall(i int) string {
+func (fake *FakeKnSourceFactory) CreateKnSourceClientArgsForCall(i int) (*rest.Config, string) {
 	fake.createKnSourceClientMutex.RLock()
 	defer fake.createKnSourceClientMutex.RUnlock()
 	argsForCall := fake.createKnSourceClientArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeKnSourceFactory) CreateKnSourceClientReturns(result1 types.KnSourceClient) {

--- a/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/types/typesfakes/fake_run_efactory.go
+++ b/plugins/source-kafka/vendor/github.com/maximilien/kn-source-pkg/pkg/types/typesfakes/fake_run_efactory.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/maximilien/kn-source-pkg/pkg/types"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
 )
 
 type FakeRunEFactory struct {
@@ -39,10 +40,11 @@ type FakeRunEFactory struct {
 	describeRunEReturnsOnCall map[int]struct {
 		result1 func(cmd *cobra.Command, args []string) error
 	}
-	KnSourceClientStub        func(string) types.KnSourceClient
+	KnSourceClientStub        func(*rest.Config, string) types.KnSourceClient
 	knSourceClientMutex       sync.RWMutex
 	knSourceClientArgsForCall []struct {
-		arg1 string
+		arg1 *rest.Config
+		arg2 string
 	}
 	knSourceClientReturns struct {
 		result1 types.KnSourceClient
@@ -230,16 +232,17 @@ func (fake *FakeRunEFactory) DescribeRunEReturnsOnCall(i int, result1 func(cmd *
 	}{result1}
 }
 
-func (fake *FakeRunEFactory) KnSourceClient(arg1 string) types.KnSourceClient {
+func (fake *FakeRunEFactory) KnSourceClient(arg1 *rest.Config, arg2 string) types.KnSourceClient {
 	fake.knSourceClientMutex.Lock()
 	ret, specificReturn := fake.knSourceClientReturnsOnCall[len(fake.knSourceClientArgsForCall)]
 	fake.knSourceClientArgsForCall = append(fake.knSourceClientArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("KnSourceClient", []interface{}{arg1})
+		arg1 *rest.Config
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("KnSourceClient", []interface{}{arg1, arg2})
 	fake.knSourceClientMutex.Unlock()
 	if fake.KnSourceClientStub != nil {
-		return fake.KnSourceClientStub(arg1)
+		return fake.KnSourceClientStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -254,17 +257,17 @@ func (fake *FakeRunEFactory) KnSourceClientCallCount() int {
 	return len(fake.knSourceClientArgsForCall)
 }
 
-func (fake *FakeRunEFactory) KnSourceClientCalls(stub func(string) types.KnSourceClient) {
+func (fake *FakeRunEFactory) KnSourceClientCalls(stub func(*rest.Config, string) types.KnSourceClient) {
 	fake.knSourceClientMutex.Lock()
 	defer fake.knSourceClientMutex.Unlock()
 	fake.KnSourceClientStub = stub
 }
 
-func (fake *FakeRunEFactory) KnSourceClientArgsForCall(i int) string {
+func (fake *FakeRunEFactory) KnSourceClientArgsForCall(i int) (*rest.Config, string) {
 	fake.knSourceClientMutex.RLock()
 	defer fake.knSourceClientMutex.RUnlock()
 	argsForCall := fake.knSourceClientArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeRunEFactory) KnSourceClientReturns(result1 types.KnSourceClient) {

--- a/plugins/source-kafka/vendor/modules.txt
+++ b/plugins/source-kafka/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/magiconair/properties
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
-# github.com/maximilien/kn-source-pkg v0.4.8-0.20200604003102-1caadf074019
+# github.com/maximilien/kn-source-pkg v0.4.10
 ## explicit
 github.com/maximilien/kn-source-pkg/pkg/client
 github.com/maximilien/kn-source-pkg/pkg/commands/source


### PR DESCRIPTION
Closes #58 

The PR is to fix error handling of kubeconfig, including a dependency library upgrade.