### PR TITLE
avoid runtime error if kubectl context is not set

### DIFF
--- a/plugins/admin/core/root.go
+++ b/plugins/admin/core/root.go
@@ -32,7 +32,7 @@ import (
 var cfgFile string
 
 // NewAdminCommand represents the base command when called without any subcommands
-func NewAdminCommand(params ...pkg.AdminParams) *cobra.Command {
+func NewAdminCommand() *cobra.Command {
 	p := &pkg.AdminParams{}
 	p.Initialize()
 

--- a/plugins/admin/pkg/command/autoscaling/update_test.go
+++ b/plugins/admin/pkg/command/autoscaling/update_test.go
@@ -21,8 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
-	"knative.dev/client-contrib/plugins/admin/pkg"
 
 	"knative.dev/client-contrib/plugins/admin/pkg/testutil"
 )
@@ -36,22 +34,16 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 			},
 			Data: make(map[string]string),
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, _ := testutil.NewTestAdminParams(cm)
+		cmd := NewAutoscalingUpdateCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd)
 		assert.ErrorContains(t, err, "'autoscaling update' requires flag(s)", err)
 	})
 
 	t.Run("config map not exist", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, _ := testutil.NewTestAdminParams()
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero")
 		assert.ErrorContains(t, err, "failed to get ConfigMaps", err)
 	})
@@ -66,11 +58,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 				"enable-scale-to-zero": "false",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero")
 		assert.NilError(t, err)
 
@@ -91,11 +80,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 				"enable-scale-to-zero": "true",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--no-scale-to-zero")
 		assert.NilError(t, err)
 
@@ -116,11 +102,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 				"enable-scale-to-zero": "true",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewAutoscalingUpdateCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewAutoscalingUpdateCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero")
 		assert.NilError(t, err)

--- a/plugins/admin/pkg/command/autoscaling/update_test.go
+++ b/plugins/admin/pkg/command/autoscaling/update_test.go
@@ -34,7 +34,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 			},
 			Data: make(map[string]string),
 		}
-		p, _ := testutil.NewTestAdminParams(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
 		cmd := NewAutoscalingUpdateCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd)
@@ -42,7 +43,8 @@ func TestNewAsUpdateSetCommand(t *testing.T) {
 	})
 
 	t.Run("config map not exist", func(t *testing.T) {
-		p, _ := testutil.NewTestAdminParams()
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewAutoscalingUpdateCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--scale-to-zero")
 		assert.ErrorContains(t, err, "failed to get ConfigMaps", err)

--- a/plugins/admin/pkg/command/domain/set.go
+++ b/plugins/admin/pkg/command/domain/set.go
@@ -54,8 +54,13 @@ func NewDomainSetCommand(p *pkg.AdminParams) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := p.NewKubeClient()
+			if err != nil {
+				return err
+			}
+
 			currentCm := &corev1.ConfigMap{}
-			currentCm, err := p.ClientSet.CoreV1().ConfigMaps(knativeServing).Get(configDomain, metav1.GetOptions{})
+			currentCm, err = client.CoreV1().ConfigMaps(knativeServing).Get(configDomain, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to get ConfigMap %s in namespace %s: %+v", configDomain, knativeServing, err)
 			}
@@ -87,7 +92,7 @@ func NewDomainSetCommand(p *pkg.AdminParams) *cobra.Command {
 
 			desiredCm.Data[domain] = value
 
-			err = utils.UpdateConfigMap(p.ClientSet, desiredCm)
+			err = utils.UpdateConfigMap(client, desiredCm)
 			if err != nil {
 				return fmt.Errorf("failed to update ConfigMap %s in namespace %s: %+v", configDomain, knativeServing, err)
 			}

--- a/plugins/admin/pkg/command/domain/set_test.go
+++ b/plugins/admin/pkg/command/domain/set_test.go
@@ -25,8 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
-	"knative.dev/client-contrib/plugins/admin/pkg"
 
 	"knative.dev/client-contrib/plugins/admin/pkg/testutil"
 )
@@ -54,22 +52,16 @@ func TestNewDomainSetCommand(t *testing.T) {
 			},
 			Data: make(map[string]string),
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, _ := testutil.NewTestAdminParams(cm)
+		cmd := NewDomainSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "")
 		assert.ErrorContains(t, err, "requires the route name", err)
 	})
 
 	t.Run("config map not exist", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, _ := testutil.NewTestAdminParams()
+		cmd := NewDomainSetCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain")
 		assert.ErrorContains(t, err, "failed to get ConfigMap", err)
 	})
@@ -82,11 +74,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 			},
 			Data: make(map[string]string),
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewDomainSetCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain")
 		assert.NilError(t, err)
 
@@ -109,11 +98,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 				"dummy.domain": "",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewDomainSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain")
 		assert.NilError(t, err)
@@ -134,11 +120,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 				"foo.bar": "",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewDomainSetCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(o, "Set knative route domain \"dummy.domain\""), "expected update information in standard output")
@@ -162,11 +145,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 				"foo.bar": "",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewDomainSetCommand(p)
 
 		o, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain", "--selector", "app=dummy")
 		assert.NilError(t, err)
@@ -199,11 +179,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 				"foo.bar": "",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainSetCommand(&p)
+		p, _ := testutil.NewTestAdminParams(cm)
+		cmd := NewDomainSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain", "--selector", "app")
 		assert.ErrorContains(t, err, "expecting the selector format 'name=value', found 'app'", err)

--- a/plugins/admin/pkg/command/domain/set_test.go
+++ b/plugins/admin/pkg/command/domain/set_test.go
@@ -52,7 +52,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 			},
 			Data: make(map[string]string),
 		}
-		p, _ := testutil.NewTestAdminParams(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
 		cmd := NewDomainSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "")
@@ -60,7 +61,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 	})
 
 	t.Run("config map not exist", func(t *testing.T) {
-		p, _ := testutil.NewTestAdminParams()
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewDomainSetCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain")
 		assert.ErrorContains(t, err, "failed to get ConfigMap", err)
@@ -179,7 +181,8 @@ func TestNewDomainSetCommand(t *testing.T) {
 				"foo.bar": "",
 			},
 		}
-		p, _ := testutil.NewTestAdminParams(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
 		cmd := NewDomainSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain", "--selector", "app")

--- a/plugins/admin/pkg/command/domain/unset.go
+++ b/plugins/admin/pkg/command/domain/unset.go
@@ -42,8 +42,13 @@ func NewDomainUnSetCommand(p *pkg.AdminParams) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := p.NewKubeClient()
+			if err != nil {
+				return err
+			}
+
 			currentCm := &corev1.ConfigMap{}
-			currentCm, err := p.ClientSet.CoreV1().ConfigMaps(knativeServing).Get(configDomain, metav1.GetOptions{})
+			currentCm, err = client.CoreV1().ConfigMaps(knativeServing).Get(configDomain, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to get configmaps: %+v", err)
 			}
@@ -57,7 +62,7 @@ func NewDomainUnSetCommand(p *pkg.AdminParams) *cobra.Command {
 				return fmt.Errorf("Knative route domain %s not found\n", domain)
 			}
 
-			err = utils.UpdateConfigMap(p.ClientSet, desiredCm)
+			err = utils.UpdateConfigMap(client, desiredCm)
 			if err != nil {
 				return fmt.Errorf("failed to update ConfigMap %s in namespace %s: %+v", configDomain, knativeServing, err)
 			}

--- a/plugins/admin/pkg/command/domain/unset_test.go
+++ b/plugins/admin/pkg/command/domain/unset_test.go
@@ -20,8 +20,6 @@ import (
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
-	"knative.dev/client-contrib/plugins/admin/pkg"
 
 	"knative.dev/client-contrib/plugins/admin/pkg/testutil"
 )
@@ -36,22 +34,16 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 			},
 			Data: make(map[string]string),
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainUnSetCommand(&p)
+		p, _ := testutil.NewTestAdminParams(cm)
+		cmd := NewDomainUnSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "")
 		assert.ErrorContains(t, err, "requires the route name", err)
 	})
 
 	t.Run("config map not exist", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainUnSetCommand(&p)
+		p, _ := testutil.NewTestAdminParams()
+		cmd := NewDomainUnSetCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain")
 		assert.ErrorContains(t, err, "failed to get configmaps", err)
 	})
@@ -66,11 +58,8 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 				"dummy.domain": "",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainUnSetCommand(&p)
+		p, _ := testutil.NewTestAdminParams(cm)
+		cmd := NewDomainUnSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "not-dummy.domain")
 		assert.ErrorContains(t, err, "Knative route domain not-dummy.domain not found", err)
@@ -87,11 +76,8 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 				"dummy2.domain": "",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(cm)
-		p := pkg.AdminParams{
-			ClientSet: client,
-		}
-		cmd := NewDomainUnSetCommand(&p)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewDomainUnSetCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy1.domain")
 		assert.NilError(t, err)
 

--- a/plugins/admin/pkg/command/domain/unset_test.go
+++ b/plugins/admin/pkg/command/domain/unset_test.go
@@ -34,7 +34,8 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 			},
 			Data: make(map[string]string),
 		}
-		p, _ := testutil.NewTestAdminParams(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
 		cmd := NewDomainUnSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "")
@@ -42,7 +43,8 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 	})
 
 	t.Run("config map not exist", func(t *testing.T) {
-		p, _ := testutil.NewTestAdminParams()
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewDomainUnSetCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "dummy.domain")
 		assert.ErrorContains(t, err, "failed to get configmaps", err)
@@ -58,7 +60,8 @@ func TestNewDomainUnSetCommand(t *testing.T) {
 				"dummy.domain": "",
 			},
 		}
-		p, _ := testutil.NewTestAdminParams(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
 		cmd := NewDomainUnSetCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--custom-domain", "not-dummy.domain")

--- a/plugins/admin/pkg/command/profiling/profiling_test.go
+++ b/plugins/admin/pkg/command/profiling/profiling_test.go
@@ -59,7 +59,8 @@ func removeProfileDataFiles(nameFilter string) {
 // TestNewProfilingCommand tests the profiling command
 func TestNewProfilingCommand(t *testing.T) {
 	t.Run("runs profiling without args", func(t *testing.T) {
-		p, _ := testutil.NewTestAdminParams()
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewProfilingCommand(p)
 		out, err := testutil.ExecuteCommand(cmd, "", "")
 		assert.NilError(t, err)
@@ -68,7 +69,8 @@ func TestNewProfilingCommand(t *testing.T) {
 
 	t.Run("runs profiling with conflict args", func(t *testing.T) {
 		// --enable and --disable can't be used together
-		p, _ := testutil.NewTestAdminParams()
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewProfilingCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--enable", "--disable")
 		assert.ErrorContains(t, err, "flags '--enable' and '--disable' can not be used together", err)
@@ -99,7 +101,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			{"--disable", "--thread-create"},
 		}
 		for _, args := range argsList {
-			p, _ = testutil.NewTestAdminParams()
+			p, client = testutil.NewTestAdminParams()
+			assert.Check(t, client != nil)
 			cmd = NewProfilingCommand(p)
 			_, err := testutil.ExecuteCommand(cmd, args...)
 			assert.ErrorContains(t, err, "flag '--enable' or '--disable' can not be used with other flags", err)
@@ -128,7 +131,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			{"--thread-create", "--save-to", "/tmp"},
 		}
 		for _, args := range argsList {
-			p, _ = testutil.NewTestAdminParams()
+			p, client = testutil.NewTestAdminParams()
+			assert.Check(t, client != nil)
 			cmd = NewProfilingCommand(p)
 			_, err := testutil.ExecuteCommand(cmd, args...)
 			assert.ErrorContains(t, err, "requires '--target' flag", err)
@@ -140,7 +144,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			{"--target", "activator", "--save-to", "/tmp"},
 		}
 		for _, args := range argsList {
-			p, _ = testutil.NewTestAdminParams()
+			p, client = testutil.NewTestAdminParams()
+			assert.Check(t, client != nil)
 			cmd = NewProfilingCommand(p)
 			_, err := testutil.ExecuteCommand(cmd, args...)
 			assert.ErrorContains(t, err, "requires '--all' or a specific profiling type flag", err)
@@ -277,7 +282,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		p, _ := testutil.NewTestAdminParams(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
 		cmd := NewProfilingCommand(p)
 		savePath := "/tmp/xsidsk2hsdks"
 
@@ -290,7 +296,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		p, _ := testutil.NewTestAdminParams(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
 		cmd := NewProfilingCommand(p)
 		_, filename, _, _ := runtime.Caller(0)
 		savePath := filename
@@ -304,7 +311,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "false"},
 		}
-		p, _ := testutil.NewTestAdminParams(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		assert.Check(t, client != nil)
 		cmd := NewProfilingCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--target", "activator", "--heap")
 		assert.ErrorContains(t, err, "profiling is not enabled, please use '--enable' to enalbe it first", err)

--- a/plugins/admin/pkg/command/profiling/profiling_test.go
+++ b/plugins/admin/pkg/command/profiling/profiling_test.go
@@ -24,29 +24,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8sfakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
 	k8stesting "k8s.io/client-go/testing"
-	"knative.dev/client-contrib/plugins/admin/pkg"
 	"knative.dev/client-contrib/plugins/admin/pkg/testutil"
 )
-
-func newProfilingCommand() *cobra.Command {
-	client := k8sfake.NewSimpleClientset(&corev1.ConfigMap{})
-	p := pkg.AdminParams{ClientSet: client}
-	return NewProfilingCommand(&p)
-}
-
-func newProfilingCommandWith(cm *corev1.ConfigMap) (*cobra.Command, *k8sfake.Clientset) {
-	client := k8sfake.NewSimpleClientset(cm)
-	p := pkg.AdminParams{ClientSet: client}
-	return NewProfilingCommand(&p), client
-}
 
 type fakeDownloader struct {
 	error error
@@ -74,14 +59,18 @@ func removeProfileDataFiles(nameFilter string) {
 // TestNewProfilingCommand tests the profiling command
 func TestNewProfilingCommand(t *testing.T) {
 	t.Run("runs profiling without args", func(t *testing.T) {
-		out, err := testutil.ExecuteCommand(newProfilingCommand(), "", "")
+		p, _ := testutil.NewTestAdminParams()
+		cmd := NewProfilingCommand(p)
+		out, err := testutil.ExecuteCommand(cmd, "", "")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(out, "  profiling [flags]"), "expected profiling help output")
 	})
 
 	t.Run("runs profiling with conflict args", func(t *testing.T) {
 		// --enable and --disable can't be used together
-		_, err := testutil.ExecuteCommand(newProfilingCommand(), "--enable", "--disable")
+		p, _ := testutil.NewTestAdminParams()
+		cmd := NewProfilingCommand(p)
+		_, err := testutil.ExecuteCommand(cmd, "--enable", "--disable")
 		assert.ErrorContains(t, err, "flags '--enable' and '--disable' can not be used together", err)
 
 		// --enable or --disable --target can't be used with other flags
@@ -110,7 +99,9 @@ func TestNewProfilingCommand(t *testing.T) {
 			{"--disable", "--thread-create"},
 		}
 		for _, args := range argsList {
-			_, err := testutil.ExecuteCommand(newProfilingCommand(), args...)
+			p, _ = testutil.NewTestAdminParams()
+			cmd = NewProfilingCommand(p)
+			_, err := testutil.ExecuteCommand(cmd, args...)
 			assert.ErrorContains(t, err, "flag '--enable' or '--disable' can not be used with other flags", err)
 		}
 
@@ -137,7 +128,9 @@ func TestNewProfilingCommand(t *testing.T) {
 			{"--thread-create", "--save-to", "/tmp"},
 		}
 		for _, args := range argsList {
-			_, err := testutil.ExecuteCommand(newProfilingCommand(), args...)
+			p, _ = testutil.NewTestAdminParams()
+			cmd = NewProfilingCommand(p)
+			_, err := testutil.ExecuteCommand(cmd, args...)
 			assert.ErrorContains(t, err, "requires '--target' flag", err)
 		}
 
@@ -147,7 +140,9 @@ func TestNewProfilingCommand(t *testing.T) {
 			{"--target", "activator", "--save-to", "/tmp"},
 		}
 		for _, args := range argsList {
-			_, err := testutil.ExecuteCommand(newProfilingCommand(), args...)
+			p, _ = testutil.NewTestAdminParams()
+			cmd = NewProfilingCommand(p)
+			_, err := testutil.ExecuteCommand(cmd, args...)
 			assert.ErrorContains(t, err, "requires '--all' or a specific profiling type flag", err)
 		}
 	})
@@ -219,7 +214,8 @@ func TestNewProfilingCommand(t *testing.T) {
 
 	t.Run("failed to enable profiling", func(t *testing.T) {
 		cm := &corev1.ConfigMap{}
-		cmd, client := newProfilingCommandWith(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		client.CoreV1().(*k8sfakecorev1.FakeCoreV1).PrependReactor("get", "configmaps",
 			func(action k8stesting.Action) (handled bool, ret k8srt.Object, err error) {
 				return true, &corev1.ConfigMap{}, errors.New("error getting configmap")
@@ -234,7 +230,8 @@ func TestNewProfilingCommand(t *testing.T) {
 
 	t.Run("failed to disable profiling", func(t *testing.T) {
 		cm := &corev1.ConfigMap{}
-		cmd, client := newProfilingCommandWith(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		client.CoreV1().(*k8sfakecorev1.FakeCoreV1).PrependReactor("get", "configmaps",
 			func(action k8stesting.Action) (handled bool, ret k8srt.Object, err error) {
 				return true, &corev1.ConfigMap{}, errors.New("error getting configmap")
@@ -248,7 +245,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "false"},
 		}
-		cmd, client := newProfilingCommandWith(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		out, err := testutil.ExecuteCommand(cmd, "--enable")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(out, "Knative Serving profiling is enabled"))
@@ -263,7 +261,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		cmd, client := newProfilingCommandWith(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		out, err := testutil.ExecuteCommand(cmd, "--disable")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(out, "Knative Serving profiling is disabled"))
@@ -278,7 +277,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		cmd, _ := newProfilingCommandWith(cm)
+		p, _ := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		savePath := "/tmp/xsidsk2hsdks"
 
 		_, err := testutil.ExecuteCommand(cmd, "--target", "activator", "--heap", "--save-to", savePath)
@@ -290,7 +290,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		cmd, _ := newProfilingCommandWith(cm)
+		p, _ := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		_, filename, _, _ := runtime.Caller(0)
 		savePath := filename
 
@@ -303,7 +304,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "false"},
 		}
-		cmd, _ := newProfilingCommandWith(cm)
+		p, _ := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--target", "activator", "--heap")
 		assert.ErrorContains(t, err, "profiling is not enabled, please use '--enable' to enalbe it first", err)
 	})
@@ -313,7 +315,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		cmd, client := newProfilingCommandWith(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		client.CoreV1().(*k8sfakecorev1.FakeCoreV1).PrependReactor("list", "pods",
 			func(action k8stesting.Action) (handled bool, ret k8srt.Object, err error) {
 				return true, &corev1.PodList{}, errors.New("error listing pods")
@@ -327,7 +330,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		cmd, client := newProfilingCommandWith(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		client.CoreV1().(*k8sfakecorev1.FakeCoreV1).PrependReactor("list", "pods",
 			func(action k8stesting.Action) (handled bool, ret k8srt.Object, err error) {
 				return true, &corev1.PodList{}, nil
@@ -341,7 +345,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		cmd, client := newProfilingCommandWith(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		pods := corev1.PodList{Items: []corev1.Pod{
 			{
 				Status: corev1.PodStatus{Phase: corev1.PodRunning},
@@ -369,7 +374,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		cmd, client := newProfilingCommandWith(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		cwd, _ := os.Getwd()
 		podName := "activator-0xxxx"
 		pods := corev1.PodList{Items: []corev1.Pod{
@@ -402,7 +408,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		cmd, client := newProfilingCommandWith(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		cwd, _ := os.Getwd()
 		podName := "activator-1xxx"
 		pods := corev1.PodList{Items: []corev1.Pod{
@@ -437,7 +444,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		cmd, client := newProfilingCommandWith(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		cwd, _ := os.Getwd()
 		podNames := []string{"activator-2xxx0", "activator-2xxx1"}
 		pods := corev1.PodList{}
@@ -477,7 +485,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		cmd, client := newProfilingCommandWith(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		cwd, _ := os.Getwd()
 		podName := "activator-3xxxx"
 		pods := corev1.PodList{Items: []corev1.Pod{
@@ -514,7 +523,8 @@ func TestNewProfilingCommand(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
 		}
-		cmd, client := newProfilingCommandWith(cm)
+		p, client := testutil.NewTestAdminParams(cm)
+		cmd := NewProfilingCommand(p)
 		cwd, _ := os.Getwd()
 		podName := "activator-4xxxx"
 		pods := corev1.PodList{Items: []corev1.Pod{

--- a/plugins/admin/pkg/command/registry/add_test.go
+++ b/plugins/admin/pkg/command/registry/add_test.go
@@ -25,21 +25,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"knative.dev/client-contrib/plugins/admin/pkg"
 	"knative.dev/client-contrib/plugins/admin/pkg/testutil"
 
 	k8srand "k8s.io/apimachinery/pkg/util/rand"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestNewRegistryAddCommand(t *testing.T) {
 
 	t.Run("incompleted args for registry add", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
+		p, _ := testutil.NewTestAdminParams()
 		cmd := NewRegistryAddCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--username", "")
@@ -53,11 +48,7 @@ func TestNewRegistryAddCommand(t *testing.T) {
 	})
 
 	t.Run("missing default serviceaccount", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
+		p, _ := testutil.NewTestAdminParams()
 		cmd := NewRegistryAddCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--username", "user", "--password", "dummy", "--server", "docker.io")
 		assert.ErrorContains(t, err, "failed to get serviceaccount")
@@ -70,14 +61,10 @@ func TestNewRegistryAddCommand(t *testing.T) {
 				Namespace: "default",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(&sa)
+		p, client := testutil.NewTestAdminParams(&sa)
+		cmd := NewRegistryAddCommand(p)
 		client.PrependReactor("create", "secrets", generateNameReactor)
 
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
-		cmd := NewRegistryAddCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--password", "dummy", "--server", "docker.io")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(o, "Private registry 'docker.io' is added for serviceaccount 'default' in namespace 'default'"), "unexpected output: %s", o)
@@ -121,14 +108,10 @@ func TestNewRegistryAddCommand(t *testing.T) {
 				Namespace: "custom-namespace",
 			},
 		}
-		client := k8sfake.NewSimpleClientset(&ns, &sa)
+		p, client := testutil.NewTestAdminParams(&ns, &sa)
+		cmd := NewRegistryAddCommand(p)
 		client.PrependReactor("create", "secrets", generateNameReactor)
 
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
-		cmd := NewRegistryAddCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "add", "--username", "user", "--password", "dummy", "--server", "docker.io", "--namespace", "custom-namespace", "--serviceaccount", "custom-serviceaccount")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(o, "Private registry 'docker.io' is added for serviceaccount 'custom-serviceaccount' in namespace 'custom-namespace'"), "unexpected output: %s", o)
@@ -173,14 +156,10 @@ func TestNewRegistryAddCommand(t *testing.T) {
 				},
 			},
 		}
-		client := k8sfake.NewSimpleClientset(&sa)
+		p, client := testutil.NewTestAdminParams(&sa)
+		cmd := NewRegistryAddCommand(p)
 		client.PrependReactor("create", "secrets", generateNameReactor)
 
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
-		cmd := NewRegistryAddCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--password", "dummy", "--server", "docker.io")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(o, "Private registry 'docker.io' is added for serviceaccount 'default' in namespace 'default'"), "unexpected output: %s", o)

--- a/plugins/admin/pkg/command/registry/add_test.go
+++ b/plugins/admin/pkg/command/registry/add_test.go
@@ -34,7 +34,8 @@ import (
 func TestNewRegistryAddCommand(t *testing.T) {
 
 	t.Run("incompleted args for registry add", func(t *testing.T) {
-		p, _ := testutil.NewTestAdminParams()
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewRegistryAddCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--username", "")
@@ -48,7 +49,8 @@ func TestNewRegistryAddCommand(t *testing.T) {
 	})
 
 	t.Run("missing default serviceaccount", func(t *testing.T) {
-		p, _ := testutil.NewTestAdminParams()
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewRegistryAddCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--username", "user", "--password", "dummy", "--server", "docker.io")
 		assert.ErrorContains(t, err, "failed to get serviceaccount")

--- a/plugins/admin/pkg/command/registry/remove_test.go
+++ b/plugins/admin/pkg/command/registry/remove_test.go
@@ -26,18 +26,11 @@ import (
 
 	"knative.dev/client-contrib/plugins/admin/pkg"
 	"knative.dev/client-contrib/plugins/admin/pkg/testutil"
-
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestNewRegistryRmCommand(t *testing.T) {
 	t.Run("incompleted args for registry remove", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
+		p, _ := testutil.NewTestAdminParams()
 		cmd := NewRegistryRmCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--username", "")
@@ -48,11 +41,7 @@ func TestNewRegistryRmCommand(t *testing.T) {
 	})
 
 	t.Run("registry not found", func(t *testing.T) {
-		client := k8sfake.NewSimpleClientset()
-
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
+		p, _ := testutil.NewTestAdminParams()
 		cmd := NewRegistryRmCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--server", "docker.io")
 		assert.NilError(t, err)
@@ -97,13 +86,9 @@ func TestNewRegistryRmCommand(t *testing.T) {
 				".dockerconfigjson": j,
 			},
 		}
-		client := k8sfake.NewSimpleClientset(&sa, &secret)
-
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
+		p, client := testutil.NewTestAdminParams(&sa, &secret)
 		cmd := NewRegistryRmCommand(p)
+
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--server", "docker.io")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(o, "ImagePullSecrets of serviceaccount 'default' in namespace 'default' is updated"), "unexpected output: %s", o)
@@ -166,13 +151,9 @@ func TestNewRegistryRmCommand(t *testing.T) {
 				".dockerconfigjson": j,
 			},
 		}
-		client := k8sfake.NewSimpleClientset(&ns, &sa, &secret)
-
-		p := &pkg.AdminParams{
-			ClientSet: client,
-		}
-
+		p, client := testutil.NewTestAdminParams(&ns, &sa, &secret)
 		cmd := NewRegistryRmCommand(p)
+
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--server", "docker.io", "--namespace", "custom-namespace", "--serviceaccount", "custom-serviceaccount")
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(o, "ImagePullSecrets of serviceaccount 'custom-serviceaccount' in namespace 'custom-namespace' is updated"), "unexpected output: %s", o)

--- a/plugins/admin/pkg/command/registry/remove_test.go
+++ b/plugins/admin/pkg/command/registry/remove_test.go
@@ -30,7 +30,8 @@ import (
 
 func TestNewRegistryRmCommand(t *testing.T) {
 	t.Run("incompleted args for registry remove", func(t *testing.T) {
-		p, _ := testutil.NewTestAdminParams()
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewRegistryRmCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd, "--username", "")
@@ -41,7 +42,8 @@ func TestNewRegistryRmCommand(t *testing.T) {
 	})
 
 	t.Run("registry not found", func(t *testing.T) {
-		p, _ := testutil.NewTestAdminParams()
+		p, client := testutil.NewTestAdminParams()
+		assert.Check(t, client != nil)
 		cmd := NewRegistryRmCommand(p)
 		o, err := testutil.ExecuteCommand(cmd, "--username", "user", "--server", "docker.io")
 		assert.NilError(t, err)

--- a/plugins/admin/pkg/testutil/command.go
+++ b/plugins/admin/pkg/testutil/command.go
@@ -18,6 +18,11 @@ import (
 	"bytes"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"knative.dev/client-contrib/plugins/admin/pkg"
 )
 
 // ExecuteCommandC execute cobra.command and catch the output
@@ -34,4 +39,14 @@ func ExecuteCommandC(root *cobra.Command, args ...string) (c *cobra.Command, out
 func ExecuteCommand(root *cobra.Command, args ...string) (output string, err error) {
 	_, o, err := ExecuteCommandC(root, args...)
 	return o, err
+}
+
+// NewTestAdminParams creates an AdminParams and kubenetes clientset for testing
+func NewTestAdminParams(objects ...runtime.Object) (*pkg.AdminParams, *k8sfake.Clientset) {
+	client := k8sfake.NewSimpleClientset(objects...)
+	return &pkg.AdminParams{
+		NewKubeClient: func() (kubernetes.Interface, error) {
+			return client, nil
+		},
+	}, client
 }


### PR DESCRIPTION
To avoid runtime error if kubectl context is not set, we delay creating the kubenets client interface like what kn admin did:
1. Added ```NewKubeClient``` in ```AdminParams``` and set it with a default kubenets client creator when initializing admin command 
2. Improved subcommand ```RunE``` function to Call ```AdminParams.NewKubeClient()``` to create kubenets client interface when need
3. Added ```NewTestAdminParams``` to help write UT.
4. Improved all UT codes with the ```NewTestAdminParams``` function.