### PR TITLE
Add go.mod file to root to allow tests to pick the correct Golang version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+// This file is purely informative for CI to pick up the correct Golang version.
+module knative.dev/client-contrib
+
+go 1.14


### PR DESCRIPTION
This ain't pretty, but it does the job and given that the repo is set to be sunset anyway, I'd just take that and run with it for now.